### PR TITLE
do not require jQuery for basic templates

### DIFF
--- a/system/modules/form_google_recaptcha/templates/form_google_recaptcha.html5
+++ b/system/modules/form_google_recaptcha/templates/form_google_recaptcha.html5
@@ -21,7 +21,7 @@ $GLOBALS['TL_JAVASCRIPT'][] = 'https://www.google.com/recaptcha/api.js';
   <script>
   function onSubmit_<?= $this->id; ?>(token)
 	{
-    jQuery('button[data-sitekey="<?= $this->sitekey; ?>"]').parents('form').submit();
+    document.querySelector('button[data-sitekey="<?= $this->sitekey; ?>"]').closest('form').submit();
   }
 </script>
 <?php $this->endblock(); ?>

--- a/system/modules/form_google_recaptcha/templates/form_submit_recaptcha.html5
+++ b/system/modules/form_google_recaptcha/templates/form_submit_recaptcha.html5
@@ -13,7 +13,7 @@ $sitekey = '';
   <script>
   function onSubmit_<?= $this->id; ?>(token) 
   {
-    jQuery('button[data-sitekey="<?= $sitekey; ?>"]').parents('form').submit();
+    document.querySelector('button[data-sitekey="<?= $sitekey; ?>"]').closest('form').submit();
   }
 </script>
 <?php $this->endblock(); ?>


### PR DESCRIPTION
When jQuery is not available, `onSubmit()` fails silently. In the two basic templates, it could be easily replaced by `document.querySelector()`.

I have not tried to replace it in the optin template, since this uses some more advanced jQuery stuff.